### PR TITLE
Fix #22: Find activity properly by traversing Context

### DIFF
--- a/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
@@ -26,6 +26,7 @@ package dev.shreyaspatil.capturable
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.Bitmap
 import android.graphics.Rect
 import android.os.Build
@@ -129,8 +130,7 @@ private suspend fun View.drawToBitmapPostLaidOut(context: Context, config: Bitma
             // "Software rendering doesn't support hardware bitmaps"
             // See this issue for the reference: https://github.com/PatilShreyas/Capturable/issues/7
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val window = (context as? Activity)?.window
-                    ?: error("Can't get window from the Context")
+                val window = context.findActivity().window
 
                 drawBitmapWithPixelCopy(
                     view = view,
@@ -179,4 +179,16 @@ private fun drawBitmapWithPixelCopy(
         },
         Handler(Looper.getMainLooper())
     )
+}
+
+/**
+ * Traverses through this [Context] and finds [Activity] wrapped inside it.
+ */
+internal fun Context.findActivity(): Activity {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    throw IllegalStateException("Unable to retrieve Activity from the current context")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/Capturable/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

# Summary

#22 Fixed retrieving `Activity` instance from `LocalContext`.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew spotlessCheck` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew spotlessApply` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [x] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] Implemented any new third-party library _(Which not existed before this change)_.
