### PR TITLE
Release v3.0.0

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/capturableExample/MainActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/capturableExample/MainActivity.kt
@@ -45,6 +45,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -64,6 +65,7 @@ import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import dev.shreyaspatil.capturableExample.ui.theme.CapturableExampleTheme
 import dev.shreyaspatil.capturableExample.ui.theme.LightGray
 import dev.shreyaspatil.capturableExample.ui.theme.Teal200
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -132,6 +134,10 @@ fun TicketScreen() {
                 }
             }
         }
+
+        LaunchedEffect(Unit) {
+            ticketBitmap = captureController.captureAsync().await()
+        }
     }
 }
 
@@ -151,6 +157,16 @@ fun Ticket(modifier: Modifier) {
             BookingDetail()
             Spacer(modifier = Modifier.size(32.dp))
             BookingQRCode()
+
+            var time by remember { mutableStateOf("") }
+            Text(time)
+
+            LaunchedEffect(Unit) {
+                repeat(1000) {
+                    delay(100)
+                    time = it.toString()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/dev/shreyaspatil/capturableExample/MainActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/capturableExample/MainActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.Card
+import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -157,16 +158,21 @@ fun Ticket(modifier: Modifier) {
             BookingDetail()
             Spacer(modifier = Modifier.size(32.dp))
             BookingQRCode()
+            Divider(Modifier.padding(vertical = 8.dp))
+            Timer()
+        }
+    }
+}
 
-            var time by remember { mutableStateOf("") }
-            Text(time)
+@Composable
+private fun Timer() {
+    var time by remember { mutableStateOf("") }
+    Text(time)
 
-            LaunchedEffect(Unit) {
-                repeat(1000) {
-                    delay(100)
-                    time = it.toString()
-                }
-            }
+    LaunchedEffect(Unit) {
+        repeat(1000) {
+            delay(1000)
+            time = "Seconds: $it"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         composeCompilerVersion = '1.5.8'
         composeBomVersion = '2024.09.02'
         jUnitVersion = '4.13.2'
+        mockkVersion = '1.13.12'
         androidJUnitTestVersion = '1.2.1'
         spotlessVersion = '6.25.0'
         mavenPublishVersion = '0.29.0'

--- a/capturable/build.gradle
+++ b/capturable/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     // Testing
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
     androidTestImplementation composeBom
     androidTestImplementation "androidx.test.ext:junit:$androidJUnitTestVersion"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"

--- a/capturable/gradle.properties
+++ b/capturable/gradle.properties
@@ -9,7 +9,7 @@ POM_PACKAGING=aar
 POM_INCEPTION_YEAR=2022
 
 GROUP=dev.shreyaspatil
-VERSION_NAME=2.1.0
+VERSION_NAME=3.0.0
 VERSION_CODE=3
 
 POM_URL=https://github.com/PatilShreyas/Capturable/

--- a/capturable/src/androidTest/java/dev/shreyaspatil/capturable/CapturableTest.kt
+++ b/capturable/src/androidTest/java/dev/shreyaspatil/capturable/CapturableTest.kt
@@ -63,7 +63,6 @@ class CapturableTest {
                 Text("Hello! Inside Capturable")
             }
 
-
             LaunchedEffect(Unit) {
                 controller.complete(captureController)
             }

--- a/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
@@ -154,4 +154,3 @@ private class CapturableModifierNode(
         drawLayer(currentGraphicsLayer)
     }
 }
-

--- a/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 
-
 /**
  * Adds a capture-ability on the Composable which can draw Bitmap from the Composable component.
  *

--- a/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/Capturable.kt
@@ -51,69 +51,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-/**
- * ***Deprecated: Use Modifier.[capturable] for replacement.***
- *
- * A composable with [content] which supports to capture [ImageBitmap] from a [content].
- *
- * Example usage:
- *
- * ```
- *  val captureController = rememberCaptureController()
- *  Capturable(
- *      controller = captureController,
- *      onCaptured = { bitmap, error ->
- *          // Do something with [bitmap]
- *          // Handle [error] if required
- *      }
- *  ) {
- *      // Composable content
- *  }
- *
- *  Button(onClick = {
- *      // Capture content
- *      captureController.capture()
- *  }) { ... }
- * ```
- *
- * @param controller A [CaptureController] which gives control to capture the [content].
- * @param modifier The [Modifier] to be applied to the layout.
- * @param onCaptured The callback which gives back [ImageBitmap] after composable is captured.
- * If any error is occurred while capturing bitmap, [Throwable] is provided.
- * @param content [Composable] content to be captured.
- */
-@OptIn(ExperimentalComposeUiApi::class)
-@Deprecated(
-    "This Composable method has been deprecated & will be removed in the future releases. " +
-        "Use Modifier `capturable()` directly.",
-    level = DeprecationLevel.WARNING
-)
-@Composable
-fun Capturable(
-    controller: CaptureController,
-    modifier: Modifier = Modifier,
-    onCaptured: (ImageBitmap?, Throwable?) -> Unit,
-    content: @Composable () -> Unit
-) {
-    val updatedOnCaptured by rememberUpdatedState(newValue = onCaptured)
-
-    Column(modifier = modifier.capturable(controller)) {
-        content()
-    }
-
-    LaunchedEffect(key1 = controller) {
-        controller.captureRequests.collect { request ->
-            try {
-                val imageBitmap = request.imageBitmapDeferred.await()
-                updatedOnCaptured(imageBitmap, null)
-            } catch (error: Throwable) {
-                updatedOnCaptured(null, error)
-            }
-        }
-    }
-}
 
 /**
  * Adds a capture-ability on the Composable which can draw Bitmap from the Composable component.

--- a/capturable/src/main/java/dev/shreyaspatil/capturable/controller/CaptureController.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/controller/CaptureController.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
  * Controller for capturing [Composable] content.
  * @see dev.shreyaspatil.capturable.Capturable for implementation details.
  */
-class CaptureController(private val graphicsLayer: GraphicsLayer) {
+class CaptureController(internal val graphicsLayer: GraphicsLayer) {
 
     /**
      * Medium for providing capture requests
@@ -67,22 +67,14 @@ class CaptureController(private val graphicsLayer: GraphicsLayer) {
     fun captureAsync(): Deferred<ImageBitmap> {
         val deferredImageBitmap = CompletableDeferred<ImageBitmap>()
         return deferredImageBitmap.also {
-            _captureRequests.trySend(
-                CaptureRequest(
-                    imageBitmapDeferred = it,
-                    graphicsLayer = graphicsLayer
-                )
-            )
+            _captureRequests.trySend(CaptureRequest(imageBitmapDeferred = it))
         }
     }
 
     /**
      * Holds information of capture request
      */
-    internal class CaptureRequest(
-        val imageBitmapDeferred: CompletableDeferred<ImageBitmap>,
-        val graphicsLayer: GraphicsLayer
-    )
+    internal class CaptureRequest(val imageBitmapDeferred: CompletableDeferred<ImageBitmap>)
 }
 
 /**

--- a/capturable/src/main/java/dev/shreyaspatil/capturable/controller/CaptureController.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/controller/CaptureController.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.asSharedFlow
  * Controller for capturing [Composable] content.
  * @see dev.shreyaspatil.capturable.Capturable for implementation details.
  */
-class CaptureController {
+class CaptureController(private val graphicsLayer: GraphicsLayer) {
 
     /**
      * Medium for providing capture requests
@@ -91,7 +91,7 @@ class CaptureController {
      */
     internal class CaptureRequest(
         val imageBitmapDeferred: CompletableDeferred<ImageBitmap>,
-        val config: Bitmap.Config
+        val graphicsLayer: GraphicsLayer
     )
 }
 
@@ -100,5 +100,6 @@ class CaptureController {
  */
 @Composable
 fun rememberCaptureController(): CaptureController {
-    return remember { CaptureController() }
+    val graphicsLayer = rememberGraphicsLayer()
+    return remember(graphicsLayer) { CaptureController(graphicsLayer) }
 }

--- a/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
+++ b/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
@@ -24,7 +24,6 @@
 */
 package dev.shreyaspatil.capturable.controller
 
-import androidx.compose.ui.graphics.layer.GraphicsLayer
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
+++ b/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
@@ -40,8 +40,7 @@ import org.junit.Test
 @Suppress("DeferredResultUnused")
 class CaptureControllerTest {
 
-    private val graphicsLayer = mockk<GraphicsLayer>()
-    private val controller = CaptureController(graphicsLayer)
+    private val controller = CaptureController(mockk())
 
     @Test
     fun captureAsync_validConfig_withNoParameters() = runTest {
@@ -54,7 +53,6 @@ class CaptureControllerTest {
         val captureRequest = captureRequestDeferred.await()
 
         // Then: Capture request should be get emitted with graphics layer
-        assertEquals(captureRequest.graphicsLayer, graphicsLayer)
         assertEquals(captureRequest.imageBitmapDeferred.isActive, true)
     }
 

--- a/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
+++ b/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
@@ -24,8 +24,8 @@
 */
 package dev.shreyaspatil.capturable.controller
 
-import android.graphics.Bitmap
-import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -38,10 +38,10 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 @Suppress("DeferredResultUnused")
-@OptIn(ExperimentalComposeApi::class)
 class CaptureControllerTest {
 
-    private val controller = CaptureController()
+    private val graphicsLayer = mockk<GraphicsLayer>()
+    private val controller = CaptureController(graphicsLayer)
 
     @Test
     fun captureAsync_validConfig_withNoParameters() = runTest {
@@ -52,27 +52,10 @@ class CaptureControllerTest {
         controller.captureAsync()
 
         val captureRequest = captureRequestDeferred.await()
-        val expectedConfig = Bitmap.Config.ARGB_8888
 
-        // Then: Capture request should be get emitted with default bitmap config
-        assertEquals(captureRequest.config, expectedConfig)
-    }
-
-    @Test
-    fun captureAsync_validConfig_withCustomParameters() = runTest {
-        // Before capturing, make sure to collect flow request eagerly
-        val captureRequestDeferred = asyncOnUnconfinedDispatcher { getRecentCaptureRequest() }
-
-        // Given: The customized config
-        val expectedConfig = Bitmap.Config.RGB_565
-
-        // When: Captured
-        controller.captureAsync(expectedConfig)
-
-        val captureRequest = captureRequestDeferred.await()
-
-        // Then: Capture request should be get emitted with default bitmap config
-        assertEquals(captureRequest.config, expectedConfig)
+        // Then: Capture request should be get emitted with graphics layer
+        assertEquals(captureRequest.graphicsLayer, graphicsLayer)
+        assertEquals(captureRequest.imageBitmapDeferred.isActive, true)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## What's new 🆕

- [#194] Using Compose's latest Graphics API to capture the content.

## Fixes 🐞

- #170 
- #193 
- #202

## Breaking changes 🔥

- Composable method `Capturable()` (_which was already deprecated_) removed in the favour of Modifier-based API.
- Removed method `CaptureRequest#capture`.
- Removed method for passing `BitmapConfig` to `captureAsync` method.