### PR TITLE
Allow subscribing to `CaptureController` multiple times

### DIFF
--- a/capturable/src/main/java/dev/shreyaspatil/capturable/controller/CaptureController.kt
+++ b/capturable/src/main/java/dev/shreyaspatil/capturable/controller/CaptureController.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.graphics.rememberGraphicsLayer
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
  * Controller for capturing [Composable] content.
@@ -51,7 +51,7 @@ class CaptureController(internal val graphicsLayer: GraphicsLayer) {
      */
     @Suppress("ktlint")
     private val _captureRequests = Channel<CaptureRequest>(capacity = Channel.UNLIMITED)
-    internal val captureRequests = _captureRequests.consumeAsFlow()
+    internal val captureRequests = _captureRequests.receiveAsFlow()
 
     /**
      * Creates and requests for a Bitmap capture with specified [config] and returns

--- a/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
+++ b/capturable/src/test/java/dev/shreyaspatil/capturable/controller/CaptureControllerTest.kt
@@ -25,7 +25,6 @@
 package dev.shreyaspatil.capturable.controller
 
 import io.mockk.mockk
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -36,7 +35,6 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import org.junit.Test
 
 @Suppress("DeferredResultUnused")
@@ -64,17 +62,8 @@ class CaptureControllerTest {
         asyncOnUnconfinedDispatcher { getRecentCaptureRequest() }.cancelAndJoin()
 
         // When: Flow is collected again
-        asyncOnUnconfinedDispatcher {
-            try {
-                getRecentCaptureRequest()
-            } catch (e: Throwable) {
-                if (e !is CancellationException) {
-                    // Then: Make sure there was no crash
-                    fail(e.message)
-                }
-            }
-            Unit
-        }.cancelAndJoin()
+        asyncOnUnconfinedDispatcher { getRecentCaptureRequest() }.cancelAndJoin()
+        // Then: It should not crash
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/Capturable/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

# Summary

The current implementation of `CaptureController` uses `Channel.consumeAsFlow()` to deliver requests. This creates a cold flow that can be consumed only once. While this works in most cases, it can lead to crashes when a controller is hoisted up, causing the internal flow to be resubscribed to. An example of this issue can be observed in a `Pager`.

```kotlin
fun Screen() {
    val controller0 = rememberCaptureController()
    val controller1 = rememberCaptureController()
    HorizontalPager(
        state = rememberPagerState { 2 },
        modifier = Modifier.fillMaxSize(),
    ) { index ->
        Box(
            contentAlignment = Alignment.Center,
            modifier = Modifier
                .capturable(if (index == 0) controller0 else controller1)
                .fillMaxSize()
        ) {
            Text("$index")
        }
    }
}
```

When a page is swiped from `0` to `1` and then back to `0`, `controller0` is reused. This reuse leads to a new subscription due to attaching to the new page, which results in a crash.

This PR replaces `Channel.consumeAsFlow()` with `Channel.receiveAsFlow()` to support subscribing multiple times.

Fixes #224

## Checklist

<!--
The current CI workflow will validate code level changes. 
Make sure that `./gradlew spotlessCheck` is passing before raising a PR. If build is failing at linting then just 
execute `./gradlew spotlessApply` which will reformat code according to our code standards.
Other than this, it's encouraged if you pay attention to the below checklist.
-->

- [x] Build and linting is passing.
- [x] This change is not breaking existing flow of a system.
- [x] I have written test case for this change.
- [x] This change is tested from all aspects.
- [ ] ~Implemented any new third-party library _(Which not existed before this change)_.~
